### PR TITLE
display update_date on posts

### DIFF
--- a/electron-nativefier/index.md
+++ b/electron-nativefier/index.md
@@ -2,6 +2,7 @@
 title: Websites as Apps
 description: Turn websites into customized desktop apps with Electron
 publish_date: 2016-04-05
+update_date: 2017-08-15
 -->
 
 <figure>

--- a/layout.html
+++ b/layout.html
@@ -34,7 +34,16 @@
           <h2 class="page__description">{{page.description}}</h2>
         {{/if}}
         {{#if page.publish_date}}
-          <time class="page__publish-date" title="{{page.publish_date}}" data-date="{{page.publish_date}}" data-format="%B %Y">{{page.publish_date}}</time>
+          <div class="page__publish-date">
+            {{#if page.update_date}}
+              Published 
+              <time title="{{page.publish_date}}" data-date="{{page.publish_date}}" data-format="%B %Y">{{page.publish_date}}</time>
+              and last updated 
+              <time title="{{page.update_date}}" data-date="{{page.update_date}}" data-format="%B %Y">{{page.update_date}}</time>
+            {{else}}
+              <time title="{{page.publish_date}}" data-date="{{page.publish_date}}" data-format="%B %Y">{{page.publish_date}}</time>
+            {{/if}}
+          </div>
         {{/if}}
       </header>
 


### PR DESCRIPTION
If there's only `publish_date`:

<img width="727" alt="screen shot 2017-08-16 at 9 53 36 am" src="https://user-images.githubusercontent.com/2289/29375137-ce76763e-8268-11e7-800b-e4639f593ae4.png">

If there's `publish_date` and `update_date`:

<img width="668" alt="screen shot 2017-08-16 at 9 54 12 am" src="https://user-images.githubusercontent.com/2289/29375166-df95f3ea-8268-11e7-96bc-4df4e204be3c.png">
