### PR TITLE
feat: add domain names below post titles on posts page

### DIFF
--- a/content/posts/index.md
+++ b/content/posts/index.md
@@ -8,7 +8,24 @@ kind: section
   {% for post in posts %}
     <li class="chronological-item">
       <span class="chronological-date" data-date="{{ post.publish_date }}" data-format="%Y %b %d">{{ post.publish_date }}</span>
-      <a class="chronological-link" href="{{ post.href }}">{{ post.title }}</a>
+      <div class="chronological-content">
+        <a class="chronological-link" href="{{ post.href }}">{{ post.title }}</a>
+        <a class="domain-name" href="{{ post.href }}">
+          {% if post.href contains 'http' %}
+            {% assign url_parts = post.href | split: '//' %}
+            {% assign domain_and_path = url_parts[1] | split: '/' %}
+            {% assign domain = domain_and_path[0] %}
+            {% if domain contains 'www.' %}
+              {% assign domain_parts = domain | split: 'www.' %}
+              {{ domain_parts[1] }}
+            {% else %}
+              {{ domain }}
+            {% endif %}
+          {% else %}
+            zeke.sikelianos.com
+          {% endif %}
+        </a>
+      </div>
     </li>
   {% endfor %}
 </ul>

--- a/styles/index.css
+++ b/styles/index.css
@@ -342,7 +342,7 @@ header {
 .chronological-item {
   display: flex;
   align-items: baseline;
-  margin: 0 0 12px 0;
+  margin: 0 0 24px 0;
   padding: 0;
   line-height: 1.6;
 }
@@ -368,11 +368,26 @@ header {
     min-width: auto;
   }
 }
+.chronological-content {
+  flex: 1;
+}
 .chronological-link {
   font-size: 1.1rem;
   text-decoration: none;
   color: #333;
   line-height: 1.4;
+  display: block;
+  margin-bottom: 2px;
+}
+.domain-name {
+  font-size: 0.8rem;
+  color: #666;
+  opacity: 0.6;
+  text-decoration: none;
+  display: block;
+}
+.domain-name:hover {
+  opacity: 0.8;
 }
 .chronological-link:hover {
   color: #000;


### PR DESCRIPTION
## Summary
- Display domain names (e.g., replicate.com, github.blog, zeke.sikelianos.com) below each post title
- Extract domain from href URLs and strip www subdomain
- Make domain names clickable links to posts
- Style domain names as smaller, semi-transparent text on their own line
- Increase spacing between posts for better readability

## Changes
- Updated posts template to extract and display domain names
- Added CSS styles for domain name display and layout improvements
- Domain names are clickable links with hover effects