### PR TITLE
feat: add thumbnails to projects page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(find:*)",
       "Bash(curl:*)",
-      "Bash(npm run lint)"
+      "Bash(npm run lint)",
+      "Bash(ln:*)"
     ],
     "deny": []
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Development Notes for AI Agents
+
+This file contains important context and instructions for AI agents working on this codebase.
+
+## Styling Guidelines
+
+**IMPORTANT**: Always edit Stylus source files (`.styl`) instead of CSS files.
+
+- **Edit**: Files in `styles/` with `.styl` extension
+- **DO NOT EDIT**: `styles/index.css` - this file is auto-generated from Stylus sources
+
+The CSS file is compiled from the Stylus sources and will be overwritten. Any changes made directly to CSS files will be lost.
+
+### Stylus File Structure
+- `styles/index.styl` - Main entry point
+- `styles/components/` - Component-specific styles
+- `styles/variables.styl` - Color and size variables
+- `styles/util.styl` - Utility classes
+- `styles/base.styl` - Base styles
+
+## Other Development Notes
+
+Add any other important context for AI agents here...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/content/projects/index.md
+++ b/content/projects/index.md
@@ -4,12 +4,21 @@ description: Things I've built for work and play. Some are still alive, and othe
 kind: section
 -->
 
-<ul class="chronological-list">
+<ul class="chronological-list project-list">
   {% for page in projectPages %}
-      <li class="chronological-item">
-        <span class="chronological-date" data-date="{{ page.publish_date }}" data-format="%Y %b %d">{{ page.publish_date }}</span>
-        <a class="chronological-link" href="{{ page.href }}">{{ page.title }}</a>
-        <div class="chronological-description">{{ page.description }}</div>
+      <li class="chronological-item project-item">
+        <a href="{{ page.href }}" class="project-thumbnail">
+          {% if page.images.thumbnail %}
+            <img src="{{ page.images.thumbnail.href }}" alt="{{ page.title }}" />
+          {% else %}
+            <div class="project-thumbnail-placeholder"></div>
+          {% endif %}
+        </a>
+        <div class="project-content">
+          <a class="chronological-link" href="{{ page.href }}">{{ page.title }}</a>
+          <div class="chronological-description">{{ page.description }}</div>
+          <span class="chronological-date" data-date="{{ page.publish_date }}" data-format="%Y %b %d">{{ page.publish_date }}</span>
+        </div>
       </li>
   {% endfor %}
 </ul>

--- a/styles/components/chronological-list.styl
+++ b/styles/components/chronological-list.styl
@@ -57,3 +57,66 @@
   
   &:hover
     opacity 0.8
+
+// Project-specific styles
+.project-item
+  display flex
+  align-items flex-start
+  gap 20px
+  margin 0 0 30px 0
+
+  @media screen and (max-width: mobile-width)
+    flex-direction column
+    gap 15px
+    margin 0 0 35px 0
+
+.project-thumbnail
+  flex-shrink 0
+  width 200px
+  height 150px
+  overflow hidden
+  border-radius 6px
+  background card-background-color
+  box-shadow 0px 2px 8px rgba(0,0,0,0.1)
+
+  @media screen and (max-width: mobile-width)
+    width 100%
+    height 200px
+    align-self center
+
+  img
+    width 100%
+    height 100%
+    object-fit cover
+    display block
+
+.project-thumbnail-placeholder
+  width 100%
+  height 100%
+  background linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%)
+  position relative
+
+  &::after
+    content "📄"
+    position absolute
+    top 50%
+    left 50%
+    transform translate(-50%, -50%)
+    font-size 24px
+    opacity 0.3
+
+.project-content
+  flex 1
+  min-width 0
+
+.project-item
+  .chronological-date
+    margin-right 0
+    margin-top 8px
+    margin-bottom 0
+    display block
+    font-size 0.8rem
+
+  .chronological-description
+    margin-left 0
+    margin-top 8px

--- a/styles/index.css
+++ b/styles/index.css
@@ -394,6 +394,71 @@ header {
 .domain-name:hover {
   opacity: 0.8;
 }
+.project-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  margin: 0 0 30px 0;
+}
+@media screen and (max-width: 480px) {
+  .project-item {
+    flex-direction: column;
+    gap: 15px;
+    margin: 0 0 35px 0;
+  }
+}
+.project-thumbnail {
+  flex-shrink: 0;
+  width: 200px;
+  height: 150px;
+  overflow: hidden;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0px 2px 8px rgba(0,0,0,0.1);
+}
+@media screen and (max-width: 480px) {
+  .project-thumbnail {
+    width: 100%;
+    height: 200px;
+    align-self: center;
+  }
+}
+.project-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.project-thumbnail-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%);
+  position: relative;
+}
+.project-thumbnail-placeholder::after {
+  content: "📄";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 24px;
+  opacity: 0.3;
+}
+.project-content {
+  flex: 1;
+  min-width: 0;
+}
+.project-item .chronological-date {
+  margin-right: 0;
+  margin-top: 8px;
+  margin-bottom: 0;
+  display: block;
+  font-size: 0.8rem;
+}
+.project-item .chronological-description {
+  margin-left: 0;
+  margin-top: 8px;
+}
 .column-1 {
   line-height: 0;
   -webkit-column-count: 1;


### PR DESCRIPTION
## Summary
- Added thumbnail display for each project with fallback placeholder
- Restructured layout: thumbnail on left, content on right  
- Made thumbnails clickable links to project pages
- Implemented responsive design for mobile devices
- Created AGENTS.md with development guidelines

## Changes
- **Layout**: Projects now show 200×150px thumbnails alongside title/description/date
- **Responsive**: Mobile switches to vertical stacking with full-width thumbnails
- **Interactivity**: Both thumbnails and titles are clickable
- **Fallback**: Projects without thumbnails show styled placeholder with document icon
- **Dev docs**: Added AGENTS.md with notes about editing Stylus vs CSS files

## Test Plan
- [x] Verify thumbnails display for projects with thumbnail.jpg/thumbnail.png
- [x] Verify placeholder appears for projects without thumbnails  
- [x] Test responsive layout on mobile devices
- [x] Confirm thumbnail and title links work correctly
- [x] Check Stylus compilation to CSS