### PR TITLE
fix: restrict GitHub Pages deployment to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches-ignore:
-    - 'gh-pages'
+    branches:
+    - main
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
Restricts GitHub Pages deployment to only trigger on pushes to the main branch, preventing unnecessary deployments from feature branches.

## Changes
- Updated `.github/workflows/deploy.yml` to use explicit `branches: [main]` filter
- Replaced `branches-ignore: ['gh-pages']` with more specific targeting
- Ensures deployments only happen on main branch merges/pushes

## Why
- Reduces CI/CD resource usage by avoiding deployments on feature branches
- Prevents potential conflicts or issues from deploying work-in-progress code
- Follows best practices for production deployments