### PR TITLE
feat: add GitHub machine translation for discussions post

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,13 @@
       "Bash(find:*)",
       "Bash(curl:*)",
       "Bash(npm run lint)",
-      "Bash(ln:*)"
+      "Bash(ln:*)",
+      "WebFetch(domain:github.blog)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh:*)"
     ],
     "deny": []
   }

--- a/data/posts.json
+++ b/data/posts.json
@@ -170,6 +170,11 @@
     "publish_date": "2020-10-14"
   },
   {
+    "title": "Machine translation for Discussions content",
+    "href": "https://github.blog/changelog/2021-07-19-machine-translation-for-discussions-content/",
+    "publish_date": "2021-07-19"
+  },
+  {
     "title": "Magnets, again",
     "href": "/magnets-again",
     "publish_date": "2019-12-21"

--- a/data/posts.json
+++ b/data/posts.json
@@ -165,14 +165,14 @@
     "publish_date": "2022-05-16"
   },
   {
-    "title": "How we open-sourced docs.github.com",
-    "href": "https://github.blog/2020-10-14-how-we-open-sourced-docs-github-com",
-    "publish_date": "2020-10-14"
-  },
-  {
     "title": "Machine translation for Discussions content",
     "href": "https://github.blog/changelog/2021-07-19-machine-translation-for-discussions-content/",
     "publish_date": "2021-07-19"
+  },
+  {
+    "title": "How we open-sourced docs.github.com",
+    "href": "https://github.blog/2020-10-14-how-we-open-sourced-docs-github-com",
+    "publish_date": "2020-10-14"
   },
   {
     "title": "Magnets, again",


### PR DESCRIPTION
## Summary

Added the GitHub blog post "Machine translation for Discussions content" to the posts list in data/posts.json.

The post is positioned chronologically between existing posts from 2020 and 2019.

> add this post to my list of posts: https://github.blog/changelog/2021-07-19-machine-translation-for-discussions-content/