### PR TITLE
feat: add print-specific styles to optimize printed output

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -992,3 +992,96 @@ table td {
   border-top-color: transparent;
   border-bottom-color: transparent;
 }
+@media print {
+  .breadcrumbs {
+    display: none !important;
+  }
+  .color-bar {
+    display: none !important;
+  }
+  footer {
+    display: none !important;
+  }
+  .site-nav,
+  div.site-nav {
+    display: none !important;
+    visibility: hidden !important;
+  }
+  #social-nav {
+    display: none !important;
+  }
+  body {
+    margin: 0;
+    padding: 0.1in 0.5in 0.25in 0.5in;
+  }
+  .page {
+    max-width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  button {
+    display: none !important;
+  }
+  a {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+  h1,
+  .page__title {
+    padding-top: 0 !important;
+    padding-bottom: 5px !important;
+    margin: 0 !important;
+  }
+  h2.page__description {
+    padding: 5px 20px !important;
+    margin: 0 !important;
+  }
+  header {
+    padding: 10px 0 20px 0 !important;
+  }
+  h2 {
+    padding-top: 20px !important;
+    padding-bottom: 10px !important;
+  }
+  h3 {
+    padding-top: 15px !important;
+    padding-bottom: 5px !important;
+  }
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    page-break-after: avoid;
+    page-break-inside: avoid;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  blockquote,
+  pre,
+  table,
+  ul,
+  ol {
+    page-break-inside: avoid;
+  }
+  li {
+    page-break-inside: avoid;
+    orphans: 2;
+    widows: 2;
+  }
+  pre {
+    border: 1px solid #ddd;
+    background: #fff !important;
+  }
+  code {
+    background: #fff !important;
+    color: #000 !important;
+  }
+}

--- a/styles/index.styl
+++ b/styles/index.styl
@@ -15,3 +15,5 @@
 
 @require 'third-party/light-syntax'
 @require 'third-party/tipsy'
+
+@require 'print'

--- a/styles/print.styl
+++ b/styles/print.styl
@@ -1,0 +1,98 @@
+// Print-specific styles
+// Hide navigation elements when printing
+
+@media print
+  // Hide header navigation elements
+  .breadcrumbs
+    display none !important
+
+  .color-bar
+    display none !important
+
+  // Hide footer and footer navigation
+  footer
+    display none !important
+
+  .site-nav, div.site-nav
+    display none !important
+    visibility hidden !important
+
+  // Hide social navigation
+  #social-nav
+    display none !important
+
+  // Optimize page layout for printing
+  // Use tighter margins to maximize content area
+  body
+    margin 0
+    padding 0.1in 0.5in 0.25in 0.5in  // Very small top, normal bottom and sides
+
+  .page
+    max-width 100% !important
+    margin 0 !important
+    padding 0 !important
+
+  // Hide any other interactive elements
+  button
+    display none !important
+
+  // Keep links styled normally for print
+  a
+    color inherit !important
+    text-decoration none !important
+
+  // Tighten up header spacing for print
+  h1, .page__title
+    padding-top 0 !important
+    padding-bottom 5px !important
+    margin 0 !important
+
+  h2.page__description
+    padding 5px 20px !important
+    margin 0 !important
+
+  header
+    padding 10px 0 20px 0 !important
+
+  // Reduce spacing for all headings
+  h2
+    padding-top 20px !important
+    padding-bottom 10px !important
+
+  h3
+    padding-top 15px !important
+    padding-bottom 5px !important
+
+  // Optimize images for printing
+  img
+    max-width 100% !important
+    page-break-inside avoid
+
+  // Smart page break handling
+  h1, h2, h3, h4, h5, h6
+    page-break-after avoid  // Keep headings with their content
+    page-break-inside avoid  // Don't break headings
+
+  // Allow paragraphs to break naturally for better page usage
+  p
+    orphans 3  // At least 3 lines at bottom of page
+    widows 3   // At least 3 lines at top of page
+
+  // Keep these elements intact when possible
+  blockquote, pre, table, ul, ol
+    page-break-inside avoid
+
+  // Prevent lonely list items
+  li
+    page-break-inside avoid
+    orphans 2
+    widows 2
+
+  // Ensure code blocks are readable
+  pre
+    border 1px solid #ddd
+    background white !important
+
+  code
+    background white !important
+    color black !important


### PR DESCRIPTION
This PR adds print-specific styles to improve the appearance of printed pages, particularly for the CV page.

## Changes

- Created new `styles/print.styl` file with print-only media queries
- Hide navigation elements when printing (header breadcrumbs, footer, site-nav, social links)
- Optimize page margins for better space utilization (0.1in top, 0.5in sides, 0.25in bottom)
- Reduce header and heading spacing to minimize whitespace
- Allow paragraphs to flow naturally across page boundaries
- Add orphan/widow control for professional text flow
- Preserve tables and code blocks from breaking across pages

## Testing locally

1. Visit http://localhost:4000/cv
2. Open print preview (Cmd+P / Ctrl+P)
3. Verify navigation elements are hidden
4. Check that text flows naturally without large gaps
5. Confirm the "Zeke Sikelianos" header is close to the top of the page

## Prompts

> add some print-only styles that hide the header and footer nav elements
> the margins on the /cv page are weird now
> don't show the links. cool idea but I don't want that
> tighten up the "Zeke Sikelianos" header on print. there's too much whitespace above and below it and the subheading
> that's looking good, but now I see the nav again (gallery / projects / etc) .. that should not display on print
> I see early page breaks on the print view, presumably to keep paragraphs intact. is there a way to change that so paragraphs can flow from page to page and not leave a bunch of whitespace?
> looking good. can you reduce the margin and or padding at the top, so the h1 is closer to the top of the printed page?