### PR TITLE
fix: replace Flash video embed with modern Vimeo iframe

### DIFF
--- a/content/solresol/index.md
+++ b/content/solresol/index.md
@@ -16,4 +16,4 @@ of arbitrarily combined syllables into English, German, Spanish, Italian, Arabic
 Today, the language is all but forgotten, and only one of his eight dictionaries has survived.
 
 
-<object width="600" height="345"><param name="allowfullscreen" value="true" /><param name="allowscriptaccess" value="always" /><param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id=4954053&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=ffffff&amp;fullscreen=1" /><embed src="http://vimeo.com/moogaloop.swf?clip_id=4954053&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=ffffff&amp;fullscreen=1" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="600" height="345"></embed></object>
+<iframe src="https://player.vimeo.com/video/4954053" width="600" height="345" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
This PR replaces the obsolete Flash/Shockwave embed on the solresol page with a modern Vimeo iframe.

The old embed was broken in production because:
1. It used HTTP URLs on an HTTPS page, causing mixed content errors
2. Flash is no longer supported in any modern browser

## Testing locally

```bash
gh repo clone zeke/zeke.sikelianos.com
cd zeke.sikelianos.com
git checkout fix/solresol-video-embed
# Start local server and visit /solresol/
```

## Prompts

> The solresol page doesn't work in production: https://zeke.sikelianos.com/solresol/
>
> But it works locally: http://localhost:4000/solresol