### PR TITLE
feat: add Web Bot Auth JWKS directory endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
+.dev.vars
 node_modules
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "get-image-colors": "^2.0.0",
         "html-frontmatter": "^1.6.1",
         "lodash": "^4.17.15",
-        "stylus": "^0.64.0"
+        "stylus": "^0.64.0",
+        "web-bot-auth": "^0.1.2"
       },
       "devDependencies": {
         "nodemon": "^1.19.4",
@@ -4991,6 +4992,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "node_modules/http-message-sig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/http-message-sig/-/http-message-sig-0.2.0.tgz",
+      "integrity": "sha512-9fXSmxsdWDuMgk6Rd5Jc8Fa/wEblmRXZyO89KPkRrGsdeAwYlUkvS5oSOw6aOKKK/qKHNTq3jCHHTRCEid6RaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "structured-headers": "2.0.2"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5694,6 +5704,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/jsonwebkey-thumbprint": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonwebkey-thumbprint/-/jsonwebkey-thumbprint-0.1.0.tgz",
+      "integrity": "sha512-4m/gJEUQH8N2NfvZFjCL8/E+vlt0FlrmHoR4T93CEXQRkC64qwRi6oQri4/eqLVXqEqXYCss0+Q7pLx6vJBqzw==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsprim": {
       "version": "1.4.1",
@@ -8493,6 +8509,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/structured-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
+      }
+    },
     "node_modules/style-to-object": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
@@ -9325,6 +9351,16 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/web-bot-auth": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/web-bot-auth/-/web-bot-auth-0.1.2.tgz",
+      "integrity": "sha512-6hIt4smUw2MtWt23frAMta1+wwan4+pZVDbWLkfrSAjMAqltr4Ahu7wY9OXVmIheg/IE+BzGL7Di89j6OZcPbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-message-sig": "^0.2.0",
+        "jsonwebkey-thumbprint": "^0.1.0"
       }
     },
     "node_modules/web-namespaces": {
@@ -13425,6 +13461,14 @@
         }
       }
     },
+    "http-message-sig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/http-message-sig/-/http-message-sig-0.2.0.tgz",
+      "integrity": "sha512-9fXSmxsdWDuMgk6Rd5Jc8Fa/wEblmRXZyO89KPkRrGsdeAwYlUkvS5oSOw6aOKKK/qKHNTq3jCHHTRCEid6RaQ==",
+      "requires": {
+        "structured-headers": "2.0.2"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -13992,6 +14036,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonwebkey-thumbprint": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonwebkey-thumbprint/-/jsonwebkey-thumbprint-0.1.0.tgz",
+      "integrity": "sha512-4m/gJEUQH8N2NfvZFjCL8/E+vlt0FlrmHoR4T93CEXQRkC64qwRi6oQri4/eqLVXqEqXYCss0+Q7pLx6vJBqzw=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -16268,6 +16317,11 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
+    "structured-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA=="
+    },
     "style-to-object": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
@@ -16927,6 +16981,15 @@
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
         "matcher-collection": "^2.0.0"
+      }
+    },
+    "web-bot-auth": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/web-bot-auth/-/web-bot-auth-0.1.2.tgz",
+      "integrity": "sha512-6hIt4smUw2MtWt23frAMta1+wwan4+pZVDbWLkfrSAjMAqltr4Ahu7wY9OXVmIheg/IE+BzGL7Di89j6OZcPbw==",
+      "requires": {
+        "http-message-sig": "^0.2.0",
+        "jsonwebkey-thumbprint": "^0.1.0"
       }
     },
     "web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "get-image-colors": "^2.0.0",
     "html-frontmatter": "^1.6.1",
     "lodash": "^4.17.15",
-    "stylus": "^0.64.0"
+    "stylus": "^0.64.0",
+    "web-bot-auth": "^0.1.2"
   },
   "devDependencies": {
     "nodemon": "^1.19.4",

--- a/script/generate-web-bot-auth-key
+++ b/script/generate-web-bot-auth-key
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+// Generate an Ed25519 keypair for Web Bot Auth
+// Outputs a JSON object with both public and private key in JWK format
+// Usage: node script/generate-web-bot-auth-key
+
+const crypto = require('crypto')
+
+async function generateKey () {
+  // Generate Ed25519 keypair
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    { name: 'Ed25519' },
+    true, // extractable
+    ['sign', 'verify']
+  )
+
+  // Export keys in JWK format
+  const publicJwk = await crypto.subtle.exportKey('jwk', publicKey)
+  const privateJwk = await crypto.subtle.exportKey('jwk', privateKey)
+
+  // Strip algorithm-specific fields that cause issues with web-bot-auth
+  // The library expects only kty, crv, x, d (for private) fields
+  const minimalPrivateJwk = {
+    kty: privateJwk.kty,
+    crv: privateJwk.crv,
+    x: privateJwk.x,
+    d: privateJwk.d
+  }
+
+  console.log('=== Web Bot Auth Ed25519 Key ===\n')
+
+  console.log('Public JWK (for JWKS directory):')
+  console.log(JSON.stringify({
+    kty: publicJwk.kty,
+    crv: publicJwk.crv,
+    x: publicJwk.x
+  }, null, 2))
+
+  console.log('\nPrivate JWK (for signing - keep secret!):')
+  console.log(JSON.stringify(minimalPrivateJwk, null, 2))
+
+  console.log('\n=== Wrangler Secret Commands ===\n')
+  console.log('Run this command to set the signing key as a Worker secret:')
+  console.log(`echo '${JSON.stringify(minimalPrivateJwk)}' | npx wrangler secret put WEB_BOT_AUTH_KEY`)
+}
+
+generateKey().catch(console.error)

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,12 @@
 /* global Headers, Request, Response */
 
+import {
+  HTTP_MESSAGE_SIGNATURES_DIRECTORY,
+  MediaType,
+  directoryResponseHeaders
+} from 'web-bot-auth'
+import { Ed25519Signer } from 'web-bot-auth/crypto'
+
 export default {
   async fetch (request, env) {
     const url = new URL(request.url)
@@ -9,6 +16,12 @@ export default {
     // from getting indexed (or outranking the canonical domain) during the
     // migration.
     const addNoIndexHeader = url.hostname.endsWith('.workers.dev')
+
+    // Serve the Web Bot Auth JWKS directory
+    // https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/
+    if (url.pathname === HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
+      return handleJwksDirectory(request, env)
+    }
 
     // If we serve `/foo` as `/foo/index.html` without redirecting, relative asset
     // URLs in the HTML resolve against `/foo` (a "file" URL), not `/foo/` (a
@@ -79,5 +92,58 @@ function withHeaders (response, addNoIndexHeader) {
     status: response.status,
     statusText: response.statusText,
     headers
+  })
+}
+
+/**
+ * Handle requests to /.well-known/http-message-signatures-directory
+ * Returns a signed JWKS directory for Web Bot Auth verification
+ */
+async function handleJwksDirectory (request, env) {
+  // Get the signing key from environment
+  const jwk = JSON.parse(env.WEB_BOT_AUTH_KEY)
+
+  // Build the JWKS directory
+  const directory = {
+    keys: [{
+      kty: jwk.kty,
+      crv: jwk.crv,
+      x: jwk.x
+    }]
+  }
+
+  // Create the signer
+  const signer = await Ed25519Signer.fromJWK(jwk)
+
+  // directoryResponseHeaders requires a ResponseRequestPair
+  // We build a minimal response object and pair it with the original request
+  const responseBody = JSON.stringify(directory)
+  const responseLike = {
+    status: 200,
+    headers: {
+      'Content-Type': MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY
+    }
+  }
+  const requestLike = {
+    method: request.method,
+    url: request.url,
+    headers: request.headers
+  }
+
+  // Sign the response with the directory-specific headers
+  const now = new Date()
+  const expires = new Date(now.getTime() + 300000) // 5 minutes
+  const signedHeaders = await directoryResponseHeaders(
+    { response: responseLike, request: requestLike },
+    [signer],
+    { created: now, expires }
+  )
+
+  return new Response(responseBody, {
+    headers: {
+      ...signedHeaders,
+      'Content-Type': MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY,
+      'Cache-Control': 'max-age=86400'
+    }
   })
 }


### PR DESCRIPTION
This PR adds support for Cloudflare's Web Bot Auth verification protocol by publishing a signed JWKS directory at `/.well-known/http-message-signatures-directory`.

## Changes

- Add `web-bot-auth` npm package for HTTP message signature handling
- Add JWKS directory endpoint to the Worker that signs responses with Ed25519
- Add helper script to generate new Ed25519 keypairs
- Add `.dev.vars` to `.gitignore`

## Live endpoints

- https://zeke.sikelianos.com/.well-known/http-message-signatures-directory
- https://website.ziki.workers.dev/.well-known/http-message-signatures-directory

## Docs

https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/