### PR TITLE
ci: add per-PR Cloudflare preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,107 @@
+name: Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+env:
+  WORKER_NAME: website
+  WORKERS_DEV_SUBDOMAIN: ziki
+
+jobs:
+  build-and-preview:
+    name: Build and preview
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      deployments: write
+    concurrency:
+      group: preview-${{ github.event.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Create GitHub deployment (pending)
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const { owner, repo } = context.repo
+            const environment = `preview/pr-${pr.number}`
+            const alias = `pr-${pr.number}`
+            const environment_url = `https://${alias}-${process.env.WORKER_NAME}.${process.env.WORKERS_DEV_SUBDOMAIN}.workers.dev`
+
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner,
+              repo,
+              ref: pr.head.sha,
+              environment,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+              description: 'Cloudflare preview'
+            })
+
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: deployment.id,
+              state: 'pending',
+              environment_url,
+              description: 'Building and uploading preview'
+            })
+
+            core.setOutput('deployment_id', String(deployment.id))
+            core.setOutput('environment', environment)
+            core.setOutput('environment_url', environment_url)
+
+      - name: Upload preview version
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: "4.62.0"
+          command: versions upload --preview-alias pr-${{ github.event.number }} --message "pr #${{ github.event.number }} (${{ github.sha }})"
+
+      - name: Mark deployment success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: Number('${{ steps.deployment.outputs.deployment_id }}'),
+              state: 'success',
+              environment_url: '${{ steps.deployment.outputs.environment_url }}',
+              description: 'Preview ready'
+            })
+
+      - name: Mark deployment failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: Number('${{ steps.deployment.outputs.deployment_id }}'),
+              state: 'failure',
+              description: 'Preview failed'
+            })


### PR DESCRIPTION
This PR adds a pull_request workflow that publishes a Cloudflare Workers Preview URL for each PR (using a stable alias like `pr-123`) and reports status via GitHub Deployments.

It shows up in the PR as a deployment environment `preview/pr-<number>` with a link to the preview URL.