### PR TITLE
refactor: serve assets via hono + workers asset routing

### DIFF
--- a/content/404.html
+++ b/content/404.html
@@ -1,0 +1,28 @@
+<!--
+title: 404.html
+description: Custom 404 (Cloudflare assets)
+layout: false
+redirect: /404.html
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>404</title>
+
+    <style type="text/css">
+      html {
+        background: url(/404/color_bars.png) no-repeat center center fixed;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+      }
+    </style>
+  </head>
+  <body>
+    <audio autoplay="autoplay" loop="loop">
+      <source src="/404/404.mp3" />
+    </audio>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "browser-date-formatter": "^2.0.1",
         "express": "^4.17.1",
         "get-image-colors": "^2.0.0",
+        "hono": "^4.9.0",
         "html-frontmatter": "^1.6.1",
         "lodash": "^4.17.15",
         "stylus": "^0.64.0"
@@ -4911,6 +4912,15 @@
       "deprecated": "Version no longer supported. Upgrade to @latest",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -13351,6 +13361,11 @@
       "version": "9.16.2",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz",
       "integrity": "sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw=="
+    },
+    "hono": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="
     },
     "hosted-git-info": {
       "version": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "browser-date-formatter": "^2.0.1",
     "express": "^4.17.1",
     "get-image-colors": "^2.0.0",
+    "hono": "^4.9.0",
     "html-frontmatter": "^1.6.1",
     "lodash": "^4.17.15",
     "stylus": "^0.64.0"

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,63 +1,21 @@
-/* global Headers, Request, Response */
+/* global Headers, Response */
 
-export default {
-  async fetch (request, env) {
-    const url = new URL(request.url)
+import { Hono } from 'hono'
 
-    // We deploy to `website.ziki.workers.dev` as a staging host while DNS still
-    // points production traffic at GitHub Pages. This prevents the staging URL
-    // from getting indexed (or outranking the canonical domain) during the
-    // migration.
-    const addNoIndexHeader = url.hostname.endsWith('.workers.dev')
+const app = new Hono()
 
-    // If we serve `/foo` as `/foo/index.html` without redirecting, relative asset
-    // URLs in the HTML resolve against `/foo` (a "file" URL), not `/foo/` (a
-    // directory URL). That breaks assets like `outpainter.mp4`.
-    const accept = request.headers.get('accept') || ''
-    const looksLikeNavigation = request.method === 'GET' && accept.includes('text/html')
-    if (looksLikeNavigation && url.pathname !== '/' && !url.pathname.endsWith('/')) {
-      const lastSegment = url.pathname.split('/').pop() || ''
-      const isFileLike = lastSegment.includes('.')
-      if (!isFileLike) {
-        const redirectUrl = new URL(request.url)
-        redirectUrl.pathname += '/'
-        return withHeaders(Response.redirect(redirectUrl.toString(), 301), addNoIndexHeader)
-      }
-    }
+app.all('*', async (c) => {
+  const url = new URL(c.req.url)
 
-    // First try exact asset match
-    let response = await env.ASSETS.fetch(request)
-    if (response.status !== 404) return withHeaders(response, addNoIndexHeader)
+  // Prevent staging `*.workers.dev` deploys from being indexed.
+  const addNoIndexHeader = url.hostname.endsWith('.workers.dev')
 
-    // For pretty URLs, retry as directory index: `/cv` -> `/cv/index.html`
-    const lastSegment = url.pathname.split('/').pop() || ''
-    const isFileLike = lastSegment.includes('.')
-    if (!isFileLike) {
-      const indexUrl = new URL(request.url)
-      indexUrl.pathname = indexUrl.pathname.replace(/\/?$/, '/') + 'index.html'
-      response = await env.ASSETS.fetch(new Request(indexUrl, request))
-      if (response.status !== 404) return withHeaders(response, addNoIndexHeader)
-    }
+  // Cloudflare's assets binding applies `html_handling` + `not_found_handling`.
+  const response = await c.env.ASSETS.fetch(c.req.raw)
+  return withHeaders(response, addNoIndexHeader)
+})
 
-    // If this looks like a browser navigation, serve our custom 404 page.
-    if (accept.includes('text/html')) {
-      const notFoundUrl = new URL(request.url)
-      notFoundUrl.pathname = '/404/index.html'
-      const notFound = await env.ASSETS.fetch(new Request(notFoundUrl, request))
-      if (notFound.status !== 404) {
-        return withHeaders(
-          new Response(notFound.body, {
-            status: 404,
-            headers: notFound.headers
-          }),
-          addNoIndexHeader
-        )
-      }
-    }
-
-    return withHeaders(response, addNoIndexHeader)
-  }
-}
+export default app
 
 function withHeaders (response, addNoIndexHeader) {
   const headers = new Headers(response.headers)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,7 @@
     "directory": "./dist",
     "binding": "ASSETS",
     "run_worker_first": true,
-    "html_handling": "none"
+    "not_found_handling": "404-page",
+    "html_handling": "auto-trailing-slash"
   }
 }


### PR DESCRIPTION
This PR switches the Worker to Hono and relies on Workers static asset routing (`html_handling` + `not_found_handling`) instead of custom URL rewriting.

It also adds a root `content/404.html` so `not_found_handling: 404-page` has a file to serve.