### PR TITLE
feat: add Umami analytics with production-only tracking

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -54,6 +54,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://unpkg.com/browser-date-formatter@3.0.2/dist.js"></script>
   <script src="/index.js"></script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="381d6269-ac72-476d-b5ce-6fe114ec46b2" data-domains="zeke.sikelianos.com"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds Umami Cloud analytics to the site.

- Adds the Umami tracking script to `layout.html`
- Uses the `data-domains` attribute to restrict tracking to `zeke.sikelianos.com`, so the beacon is inert on `*.workers.dev` staging deploys