### PR TITLE
feat: add Link response headers for agent discovery (RFC 8288)

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -12,12 +12,12 @@ app.all('*', async (c) => {
 
   // Cloudflare's assets binding applies `html_handling` + `not_found_handling`.
   const response = await c.env.ASSETS.fetch(c.req.raw)
-  return withHeaders(response, addNoIndexHeader)
+  return withHeaders(response, addNoIndexHeader, url.origin)
 })
 
 export default app
 
-function withHeaders (response, addNoIndexHeader) {
+function withHeaders (response, addNoIndexHeader, origin) {
   const headers = new Headers(response.headers)
   let changed = false
 
@@ -27,8 +27,14 @@ function withHeaders (response, addNoIndexHeader) {
   }
 
   const contentType = headers.get('content-type')
-  if (contentType && /^text\/html\b/i.test(contentType) && !/charset=/i.test(contentType)) {
-    headers.set('content-type', `${contentType}; charset=utf-8`)
+  if (contentType && /^text\/html\b/i.test(contentType)) {
+    if (!/charset=/i.test(contentType)) {
+      headers.set('content-type', `${contentType}; charset=utf-8`)
+      changed = true
+    }
+
+    // Link response headers for agent discovery (RFC 8288)
+    headers.append('Link', `<${origin}/feed.xml>; rel="alternate"; type="application/rss+xml"; title="RSS Feed"`)
     changed = true
   }
 


### PR DESCRIPTION
This PR adds a `Link` response header to all HTML responses served by the worker, advertising the site's RSS feed for agent and client discovery per [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288).

All HTML responses now include:

```
Link: <https://zeke.sikelianos.com/feed.xml>; rel="alternate"; type="application/rss+xml"; title="RSS Feed"
```

This helps automated agents, feed readers, and crawlers discover the site's machine-readable content without parsing HTML.