### PR TITLE
feat: add Content-Signal directives to robots.txt

### DIFF
--- a/middleware/robots.js
+++ b/middleware/robots.js
@@ -3,7 +3,21 @@ const SITE_URL = process.env.SITE_URL || 'https://zeke.sikelianos.com'
 module.exports = function robots (req, res, next) {
   if (req.path !== '/robots.txt') return next()
 
-  const body = `User-agent: GPTBot
+  const body = `# As a condition of accessing this website, you agree to abide by the following content signals:
+# (a) If a content-signal = yes, you may collect content for the corresponding use.
+# (b) If a content-signal = no, you may not collect content for the corresponding use.
+# (c) If the website operator does not include a content signal for a corresponding use,
+#     the website operator neither grants nor restricts permission via content signal
+#     with respect to the corresponding use.
+# The content signals and their meanings are:
+# search: building a search index and providing search results (e.g., returning hyperlinks
+#   and short excerpts from your website's contents). Search does not include providing
+#   AI-generated search summaries.
+# ai-input: inputting content into one or more AI models (e.g., retrieval augmented generation,
+#   grounding, or other real-time taking of content for generative AI search answers).
+# ai-train: training or fine-tuning AI models.
+
+User-agent: GPTBot
 Allow: /
 
 User-agent: OAI-SearchBot
@@ -16,6 +30,7 @@ User-agent: Google-Extended
 Allow: /
 
 User-agent: *
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
 Allow: /
 Sitemap: ${SITE_URL}/sitemap.xml
 `

--- a/script/test-build.js
+++ b/script/test-build.js
@@ -40,6 +40,7 @@ async function main () {
 
   const robotsBody = fs.readFileSync(robotsPath, 'utf8')
   assert.ok(robotsBody.includes(`Sitemap: ${SITE_URL}/sitemap.xml`), 'robots sitemap reference')
+  assert.ok(robotsBody.includes('Content-Signal:'), 'robots.txt has Content-Signal directive')
 
   const llmsBody = fs.readFileSync(llmsPath, 'utf8')
   const llmsLines = llmsBody.split(/\r?\n/)


### PR DESCRIPTION
This PR adds [Content Signals](https://contentsignals.org/) to the site's `robots.txt`, declaring AI content usage preferences per the [IETF draft](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/).

The machine-readable directive under `User-agent: *`:

```
Content-Signal: search=yes, ai-train=yes, ai-input=yes
```

This matches the site's existing permissive stance (GPTBot, Claude-Web, etc. are all explicitly allowed). The human-readable policy comments above the directives explain each signal's meaning to anyone reviewing the file.

A test assertion was added to verify the built `robots.txt` contains the `Content-Signal` directive.