### PR TITLE
docs(browsers-in-the-cloud): embed intro video

### DIFF
--- a/content/browsers-in-the-cloud/index.md
+++ b/content/browsers-in-the-cloud/index.md
@@ -7,7 +7,7 @@ kind: project
 
 I recently wrote about [how to drive your local Chrome browser with an AI agent](/driving-chrome-with-an-agent). In this post I'll show you how to do the same thing with browsers running in the cloud.
 
-<video controls poster="/browsers-in-the-cloud/thumbnail.jpg">
+<video controls>
   <source src="https://assets.zeke.sikelianos.com/browsers-in-the-cloud/browsers-in-the-cloud.mp4" type="video/mp4">
 </video>
 

--- a/content/browsers-in-the-cloud/index.md
+++ b/content/browsers-in-the-cloud/index.md
@@ -7,6 +7,10 @@ kind: project
 
 I recently wrote about [how to drive your local Chrome browser with an AI agent](/driving-chrome-with-an-agent). In this post I'll show you how to do the same thing with browsers running in the cloud.
 
+<video controls poster="/browsers-in-the-cloud/thumbnail.jpg">
+  <source src="https://assets.zeke.sikelianos.com/browsers-in-the-cloud/browsers-in-the-cloud.mp4" type="video/mp4">
+</video>
+
 <p style="margin-bottom: 0.25rem; opacity: 0.75; font-size: 0.9rem">Copy this and paste it into your agent:</p>
 
 ```plaintext


### PR DESCRIPTION
This PR adds an embedded video to the top of the [Browsers in the Cloud](https://zeke.sikelianos.com/browsers-in-the-cloud) post, right under the intro paragraph.

The 32 MB MP4 is hosted on R2 at https://assets.zeke.sikelianos.com/browsers-in-the-cloud/browsers-in-the-cloud.mp4 and follows the same `<video controls poster=...>` pattern used in [Ten things I love about Replicate](/ten-things-i-love-about-replicate).