### PR TITLE
feat: add newsletter signup form to post/project/talk pages

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -102,6 +102,24 @@
     </div>
   </article>
 
+  {% if page.publish_date %}
+  <section class="newsletter-signup">
+    <div class="text-column">
+      <p class="newsletter-signup__description">
+        <svg class="newsletter-signup__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+        Subscribe to get an email when I publish new stuff.
+      </p>
+      <form class="newsletter-signup__form" action="https://mail.ziki.boo/subscribe" method="POST" novalidate>
+        <div class="newsletter-signup__fields">
+          <input class="newsletter-signup__input" type="email" name="email" placeholder="you@example.com" required autocomplete="email">
+          <button class="newsletter-signup__button" type="submit">Subscribe</button>
+        </div>
+        <p class="newsletter-signup__status" aria-live="polite" hidden></p>
+      </form>
+    </div>
+  </section>
+  {% endif %}
+
   <footer>
     <div class="site-nav">
       <a href="/">Gallery</a>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,4 +1,48 @@
 window.addEventListener('DOMContentLoaded', () => {
+  const newsletterForm = document.querySelector('.newsletter-signup__form')
+  if (newsletterForm) {
+    const input = newsletterForm.querySelector('.newsletter-signup__input')
+    const button = newsletterForm.querySelector('.newsletter-signup__button')
+    const status = newsletterForm.querySelector('.newsletter-signup__status')
+
+    newsletterForm.addEventListener('submit', async (e) => {
+      e.preventDefault()
+      const email = input.value.trim()
+      if (!email) return
+
+      button.disabled = true
+      status.hidden = true
+      status.className = 'newsletter-signup__status'
+
+      try {
+        const res = await fetch(newsletterForm.action, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email })
+        })
+
+        if (res.ok) {
+          input.hidden = true
+          button.hidden = true
+          status.textContent = 'You\'re subscribed. Talk soon.'
+          status.hidden = false
+        } else {
+          const body = await res.json().catch(() => ({}))
+          status.textContent = body.error || 'Something went wrong. Try again.'
+          status.classList.add('is-error')
+          status.hidden = false
+          button.disabled = false
+        }
+      } catch (_) {
+        status.textContent = 'Could not reach the server. Try again later.'
+        status.classList.add('is-error')
+        status.hidden = false
+        button.disabled = false
+      }
+    })
+  }
+
+
   if ('browserDateFormatter' in window) {
     browserDateFormatter()
   }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -24,7 +24,7 @@ window.addEventListener('DOMContentLoaded', () => {
         if (res.ok) {
           input.hidden = true
           button.hidden = true
-          status.textContent = 'You\'re subscribed. Talk soon.'
+          status.textContent = 'Check your email to confirm your subscription.'
           status.hidden = false
         } else {
           const body = await res.json().catch(() => ({}))

--- a/styles/components/newsletter.styl
+++ b/styles/components/newsletter.styl
@@ -1,0 +1,77 @@
+.newsletter-signup
+  margin 60px auto 0
+  border-top 1px solid #ddd
+  padding 48px 20px 60px
+
+.newsletter-signup__description
+  display flex
+  align-items center
+  gap 8px
+  font-size 1rem
+  color color-text
+  margin 0 0 20px
+
+.newsletter-signup__icon
+  flex-shrink 0
+  width 16px
+  height 16px
+  color color-quote
+  position relative
+  top -1px
+
+.newsletter-signup__form
+  width 100%
+
+.newsletter-signup__fields
+  display flex
+  gap 8px
+  align-items stretch
+
+  @media (max-width: mobile-width)
+    flex-direction column
+
+.newsletter-signup__input
+  flex 1
+  font-size 1rem
+  padding 10px 14px
+  border 1px solid #ccc
+  border-radius 3px
+  background white
+  color color-text
+  font-family base-font-family
+  outline none
+  transition border-color 0.15s
+
+  &:focus
+    border-color #888
+
+  &::placeholder
+    color #aaa
+
+.newsletter-signup__button
+  flex-shrink 0
+  font-size 1rem
+  padding 10px 20px
+  background color-main
+  color white
+  border none
+  border-radius 3px
+  cursor pointer
+  font-family base-font-family
+  letter-spacing 0.02em
+  transition opacity 0.15s
+
+  &:hover
+    opacity 0.75
+
+  &:disabled
+    opacity 0.4
+    cursor default
+
+.newsletter-signup__status
+  margin 12px 0 0
+  font-size 0.95rem
+  color color-text
+
+  &.is-error
+    color #b00

--- a/styles/index.css
+++ b/styles/index.css
@@ -658,6 +658,86 @@ input[type=submit] {
   height: 100%;
   width: 20%;
 }
+.newsletter-signup {
+  margin: 60px auto 0;
+  border-top: 1px solid #ddd;
+  padding: 48px 20px 60px;
+}
+.newsletter-signup__description {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  color: #333;
+  margin: 0 0 20px;
+}
+.newsletter-signup__icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: #666;
+  position: relative;
+  top: -1px;
+}
+.newsletter-signup__form {
+  width: 100%;
+}
+.newsletter-signup__fields {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+@media (max-width: 480px) {
+  .newsletter-signup__fields {
+    flex-direction: column;
+  }
+}
+.newsletter-signup__input {
+  flex: 1;
+  font-size: 1rem;
+  padding: 10px 14px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  color: #333;
+  font-family: Georgia, serif;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.newsletter-signup__input:focus {
+  border-color: #888;
+}
+.newsletter-signup__input::placeholder {
+  color: #aaa;
+}
+.newsletter-signup__button {
+  flex-shrink: 0;
+  font-size: 1rem;
+  padding: 10px 20px;
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: Georgia, serif;
+  letter-spacing: 0.02em;
+  transition: opacity 0.15s;
+}
+.newsletter-signup__button:hover {
+  opacity: 0.75;
+}
+.newsletter-signup__button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.newsletter-signup__status {
+  margin: 12px 0 0;
+  font-size: 0.95rem;
+  color: #333;
+}
+.newsletter-signup__status.is-error {
+  color: #b00;
+}
 .page__content {
   position: relative;
 }

--- a/styles/index.styl
+++ b/styles/index.styl
@@ -9,6 +9,7 @@
 @require 'components/footer'
 @require 'components/forms'
 @require 'components/header'
+@require 'components/newsletter'
 @require 'components/page'
 @require 'components/social-nav'
 @require 'components/tables'


### PR DESCRIPTION
This PR adds a newsletter signup form (ziki mail) to the bottom of all post, project, and talk pages.

- Appears on any page with a `publish_date` frontmatter field
- Hidden on listing pages (gallery, projects, talks index, etc.)
- Submits via `fetch()` to `https://mail.ziki.boo/subscribe` with `{ email }` as JSON
- On success, collapses the form and shows a confirmation message
- On error, shows the server error and re-enables the button
- Bell icon + "Subscribe to get an email when I publish new stuff."
- New `styles/components/newsletter.styl` component; wired into `styles/index.styl`
- Client-side handler added to `scripts/index.js`

The `mail.ziki.boo` endpoint doesn't exist yet — that's a follow-up Worker to be built in the `zeke/ziki.boo` repo.