### PR TITLE
style: increase prose font size

### DIFF
--- a/styles/variables.styl
+++ b/styles/variables.styl
@@ -31,4 +31,4 @@ text-column-width = 740px
 
 mobile-width = 480px
 
-base-font-size = 1.1rem
+base-font-size = 1.2rem


### PR DESCRIPTION
This PR bumps `base-font-size` from `1.1rem` to `1.2rem` (about 9% larger), making body text easier to read.

Headings, nav, and code blocks use their own explicit `rem` sizes, so they're unaffected.