### PR TITLE
fix: point Beaver Brook links at beaver.ziki.boo

### DIFF
--- a/content/beaver-brook-application/index.md
+++ b/content/beaver-brook-application/index.md
@@ -1,6 +1,6 @@
 <!--
 title: Beaver Brook Application
 description: My application to the Beaver Brook building school
-redirect: http://beaver.zeke.sikelianos.com
+redirect: https://beaver.ziki.boo
 noIndex: true
 -->

--- a/content/beaver-brook/index.md
+++ b/content/beaver-brook/index.md
@@ -20,7 +20,7 @@ Beaver Brook is an architectural design and building school in the woods of upst
 {% endfor %}
 
 <figure>
-  <a href="http://beaver.zeke.sikelianos.com/">
+  <a href="https://beaver.ziki.boo/">
     <img src="/beaver-brook/sauna.jpg" alt="Beaver Brook Sauna" />
   </a>
   <figcaption>The Completed Sauna</figcaption>
@@ -28,6 +28,6 @@ Beaver Brook is an architectural design and building school in the woods of upst
 
 ## See Also
 
-- [My application to Beaver Brook](http://beaver.zeke.sikelianos.com)
+- [My application to Beaver Brook](https://beaver.ziki.boo)
 - [The Beaver Brook website](http://beaverbrook.com)
 - [All my photos on Flickr](https://www.flickr.com/photos/sikelianos/collections/72157635269715529/)

--- a/content/bio/index.md
+++ b/content/bio/index.md
@@ -9,7 +9,7 @@ noIndex: true
   <figcaption>Cosmos, Zeke, (Toasty) Rowan</figcaption>
 </figure>
 
-I grew up in a family of <a href="http://beaver.zeke.sikelianos.com/">artists and artisans</a>, and
+I grew up in a family of <a href="https://beaver.ziki.boo/">artists and artisans</a>, and
 though I ended up in a [technical field](/github), I still consider design to an essential part of my work. I believe that <a href="https://en.wikipedia.org/wiki/Hacker_ethic">information wants to be free</a>, and the work I do is always in the service of that idea.
 
 Today I'm a software developer at <a href="https://github.com/about">GitHub</a>, working on <a href="http://electron.atom.io">Electron</a>, an open-source project for building native applications using open web technologies like HTML, CSS, and Javascript.


### PR DESCRIPTION
This PR updates the links to my Beaver Brook application, which used to live at `beaver.zeke.sikelianos.com` on an S3 static website bucket. That bucket is gone, so the site now runs as a Cloudflare Worker at https://beaver.ziki.boo. The old hostname 301-redirects there, but the links may as well point at the canonical URL.

Touches the Beaver Brook project page, the redirect stub at `/beaver-brook-application`, and one link in my bio.