### PR TITLE
refactor: link slop disclosures to the writeup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Every scanned page discloses how much of its prose was written by AI.
 - Source of truth is [zeke/slop-detector](https://github.com/zeke/slop-detector), which scans the live site with Pangram and commits per-page results.
 - `script/sync-slop` fetches its `results/latest.json` into `data/slop.json`. `.github/workflows/sync-slop.yml` runs it daily and commits changes, which triggers a deploy.
 - `lib/slop.js` shapes that file for templates: a sorted `pages` list and a `byPath` lookup, with percentages precomputed. A page counts as AI-written at 5% or more combined AI + AI-assisted, since Pangram attributes a percent or two of some human posts to AI.
-- `layout.html` renders the indicator below the prose. Pages missing from `data/slop.json` get nothing.
+- `layout.html` renders the indicator below the prose, linking to `/slop-detection` for context (except on `/slop-detection` itself, which links to its own per-page data). Pages missing from `data/slop.json` get nothing.
 - The `/slop-detection` table is generated from the same data.
 - Anything rendered from slop data must carry `class="slop-indicator"` or `data-slop-ignore`, so slop-detector strips it before hashing a page's prose. Without that, results would change a page's text and trigger a paid rescan on every run.
 

--- a/layout.html
+++ b/layout.html
@@ -115,12 +115,12 @@
       {% if pageSlop.isAi %}
         <p class="slop-indicator slop-indicator--ai">
           ⚠️ Disclosure: {{pageSlop.aiPercent}}% of this post was written by AI.
-          <a href="{{pageSlop.dataUrl}}">See the analysis.</a>
+          <a href="{% if page.href == '/slop-detection' %}{{pageSlop.dataUrl}}{% else %}/slop-detection{% endif %}">See the analysis.</a>
         </p>
       {% elsif pageSlop %}
         <p class="slop-indicator slop-indicator--human">
           {% if pageSlop.humanPercent == 100 %}This post was written entirely by a human.{% else %}{{pageSlop.humanPercent}}% of this post was written by a human.{% endif %}
-          <a href="{{pageSlop.dataUrl}}">See the analysis.</a>
+          <a href="{% if page.href == '/slop-detection' %}{{pageSlop.dataUrl}}{% else %}/slop-detection{% endif %}">See the analysis.</a>
         </p>
       {% endif %}
     </div>

--- a/test/slop.test.js
+++ b/test/slop.test.js
@@ -38,7 +38,7 @@ describe('slop indicator', () => {
     const percent = Math.round((page.fractionAi + page.fractionAiAssisted) * 100)
 
     expect(res.body).toContain(`Disclosure: ${percent}% of this post was written by AI`)
-    expect(res.body).toContain(page.dataUrl)
+    expect(res.body).toContain('<a href="/slop-detection">See the analysis.</a>')
     // below the prose, at the end of the page content
     expect(res.body).toMatch(/<p class="slop-indicator slop-indicator--ai"[\s\S]*<\/p>\s*<\/div>\s*<\/article>/)
   })
@@ -48,7 +48,7 @@ describe('slop indicator', () => {
     const res = await request(server, page.path)
 
     expect(res.body).toContain('This post was written entirely by a human')
-    expect(res.body).toContain(page.dataUrl)
+    expect(res.body).toContain('<a href="/slop-detection">See the analysis.</a>')
     // below the prose, at the end of the page content
     expect(res.body).toMatch(/<p class="slop-indicator slop-indicator--human"[\s\S]*<\/p>\s*<\/div>\s*<\/article>/)
   })


### PR DESCRIPTION
This PR points the "See the analysis" link on each page's slop disclosure at [/slop-detection](https://zeke.sikelianos.com/slop-detection) instead of the raw data in the slop-detector repo.

Readers get the context for what the disclosure means first, and can dig into per-page numbers from the table there. The disclosure on /slop-detection itself still links to its own data, since linking to the page you're already on is useless.
