### PR TITLE
fix(redirects): match paths with trailing slashes

### DIFF
--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,7 +1,8 @@
 const redirectMap = require('../data/redirects.json')
 
 module.exports = function redirects (req, res, next) {
-  const destination = redirectMap[req.path]
+  const path = req.path.length > 1 ? req.path.replace(/\/+$/, '') : req.path
+  const destination = redirectMap[path]
   if (!destination) return next()
   res.redirect(301, destination)
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -8,7 +8,7 @@ const app = new Hono()
 app.all('*', async (c) => {
   const url = new URL(c.req.url)
 
-  const destination = redirects[url.pathname]
+  const destination = redirects[stripTrailingSlash(url.pathname)]
   if (destination) {
     return c.redirect(new URL(destination, url.origin).toString(), 301)
   }
@@ -22,6 +22,10 @@ app.all('*', async (c) => {
 })
 
 export default app
+
+function stripTrailingSlash (pathname) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname
+}
 
 function withHeaders (response, addNoIndexHeader, origin) {
   const headers = new Headers(response.headers)


### PR DESCRIPTION
This PR fixes redirects for paths with a trailing slash. `/resume` redirected to `/cv`, but `/resume/` fell through to the assets binding and returned a 404.

Both the worker and the dev middleware now strip the trailing slash before looking up the path in `data/redirects.json`.