### PR TITLE
fix(urls): drop trailing slashes from canonical urls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ This repo builds a static personal site from local content and deploys it to Clo
 - Alternate/staging: https://website.ziki.workers.dev
 - Hosted on Cloudflare (Workers + static assets)
 - `src/worker.js` adds `X-Robots-Tag: noindex, nofollow` on `*.workers.dev` to avoid indexing the staging host.
-- `src/worker.js` also handles pretty URLs (`/cv` -> `/cv/index.html`), adds trailing slashes for navigations, and serves the custom `content/404/` page for HTML 404s.
+- Canonical URLs have no trailing slash. In production this comes from `html_handling: "drop-trailing-slash"` in `wrangler.jsonc`, which serves `/cv` from `dist/cv/index.html` and 307s `/cv/` to `/cv`. In dev, `middleware/trailing-slash.js` does the same with a 301.
+- Redirects are matched before trailing slashes are normalized (in both `src/worker.js` and `middleware/index.js`), so `/resume/` goes straight to `/cv` in one hop.
 - Cloudflare zone setting **Hotlink Protection is intentionally OFF** for `sikelianos.com`. It was blocking any cross-origin `Referer` request to image assets with a 403, which broke `og:image`/`twitter:image` fetches from OpenGraph scanners and some link-preview tools. Don't re-enable it.
 
 ## Site Structure

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,5 +1,6 @@
 module.exports = function (app) {
   app.use(require('./redirects'))
+  app.use(require('./trailing-slash'))
   app.use(require('./load-pages'))
   app.use(require('./rss'))
   app.use(require('./sitemap'))

--- a/middleware/trailing-slash.js
+++ b/middleware/trailing-slash.js
@@ -1,0 +1,8 @@
+// Canonical URLs have no trailing slash, matching the production
+// `html_handling: drop-trailing-slash` setting in wrangler.jsonc.
+module.exports = function trailingSlash (req, res, next) {
+  if (req.path === '/' || !req.path.endsWith('/')) return next()
+
+  const search = req.originalUrl.slice(req.path.length)
+  res.redirect(301, req.path.replace(/\/+$/, '') + search)
+}

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -1,0 +1,55 @@
+const http = require('http')
+const app = require('../server')
+
+function request (server, path) {
+  return new Promise((resolve, reject) => {
+    const url = `http://localhost:${server.address().port}${path}`
+    http.get(url, (res) => {
+      res.resume()
+      res.on('end', () => resolve({ status: res.statusCode, location: res.headers.location }))
+      res.on('error', reject)
+    }).on('error', reject)
+  })
+}
+
+let server
+
+describe('redirects', () => {
+  beforeAll((done) => {
+    server = http.createServer(app)
+    server.listen(0, done)
+  })
+
+  afterAll((done) => {
+    server.close(done)
+  })
+
+  it('redirects a known path', async () => {
+    const res = await request(server, '/resume')
+    expect(res.status).toBe(301)
+    expect(res.location).toBe('/cv')
+  })
+
+  it('redirects a known path with a trailing slash in one hop', async () => {
+    const res = await request(server, '/resume/')
+    expect(res.status).toBe(301)
+    expect(res.location).toBe('/cv')
+  })
+
+  it('drops trailing slashes', async () => {
+    const res = await request(server, '/cv/')
+    expect(res.status).toBe(301)
+    expect(res.location).toBe('/cv')
+  })
+
+  it('preserves the query string when dropping a trailing slash', async () => {
+    const res = await request(server, '/cv/?foo=bar')
+    expect(res.status).toBe(301)
+    expect(res.location).toBe('/cv?foo=bar')
+  })
+
+  it('leaves the homepage alone', async () => {
+    const res = await request(server, '/')
+    expect(res.status).toBe(200)
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,6 @@
     "binding": "ASSETS",
     "run_worker_first": true,
     "not_found_handling": "404-page",
-    "html_handling": "auto-trailing-slash"
+    "html_handling": "drop-trailing-slash"
   }
 }


### PR DESCRIPTION
This PR makes URLs without a trailing slash canonical, so `/cv/` redirects to `/cv` instead of both working.

- `wrangler.jsonc`: `html_handling` changes from `auto-trailing-slash` to `drop-trailing-slash`, so the assets binding serves `/cv` from `dist/cv/index.html` and 307s `/cv/`, `/cv/index.html`, and `/cv.html` to `/cv`.
- `middleware/trailing-slash.js`: same behavior in the dev server, as a 301, with the query string preserved.
- It runs after the redirects middleware, so `/resume/` still goes straight to `/cv` in one hop.

Internal links and sitemap entries were already slashless, so nothing else changes. Verified against `dist/` with `wrangler dev`.