### PR TITLE
fix: make homepage card columns fill available width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ This repo builds a static personal site from local content and deploys it to Clo
 - Cloudflare config: `wrangler.jsonc` (serves `dist/` via the `assets` binding; `run_worker_first: true`, `html_handling: none`).
 - Deployment happens via GitHub Actions: `.github/workflows/deploy.yml` (runs `npm ci`, `npm run build`, then `wrangler deploy`, then a small smoke test).
 - Prefer repo scripts under `script/`/`scripts/` over ad-hoc commands.
+- The build scraper reserves port 4001. Use a different port for a concurrent dev server.
 
 ## Slop indicators
 
@@ -44,6 +45,8 @@ Every scanned page discloses how much of its prose was written by AI.
 ## Styling
 
 Plain CSS, no build step. Edit files directly under `styles/`.
+
+- The homepage uses `.card-gallery` and an auto-fit CSS grid, capped at three columns. Cards fill the available width with `--card-gutter-width` gaps; keep it independent of `.main-column` viewport breakpoints.
 
 - Entry point: `styles/index.css`, which uses native `@import` to pull in `variables.css`, `theme.css`, `util.css`, `base.css`, `styles/components/*.css`, `styles/third-party/tipsy.css`, and `print.css`.
 - Design tokens live in `styles/variables.css` (sizes, fonts) and `styles/theme.css` (light/dark colors) as CSS custom properties (`--color-*`, `--card-width`, etc). Prefer adding new tokens there over hardcoding values.

--- a/content/index.md
+++ b/content/index.md
@@ -5,7 +5,7 @@ noIndex: true
 kind: section
 -->
 
-<div class="main-column">
+<div class="card-gallery">
 
   <ul class="cards">
     {% for page in pages %}

--- a/styles/components/card.css
+++ b/styles/components/card.css
@@ -1,32 +1,20 @@
+.page__content > .card-gallery {
+  max-width: var(--width-of-three-columns);
+}
+
 /* .cards' shared list-reset declarations live in util.css (see .vanilla-list) */
 .cards {
-  display: block;
-  float: none;
-  clear: both;
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--card-width)), 1fr));
+  gap: var(--card-gutter-width);
 }
 
-/* .card's shared float declarations live in util.css (see .float-left) */
 .card {
-  height: 360px;
-  margin: 0 0 40px 0;
-  padding: 0 calc(var(--card-gutter-width) / 2) 20px calc(var(--card-gutter-width) / 2);
-}
-
-/* max-width: 480px. .card also extends .float-none within this breakpoint. */
-@media screen and (max-width: 480px) {
-  .card {
-    float: none;
-    clear: both;
-    overflow: hidden;
-    width: 100%;
-    height: auto;
-    padding: 0;
-  }
+  min-width: 0;
 }
 
 .card-inner {
-  width: var(--card-width);
+  width: 100%;
   display: block;
   -webkit-box-shadow: 0px 1px 15px 1px var(--color-shadow);
   -moz-box-shadow: 0px 1px 15px 1px var(--color-shadow);
@@ -35,7 +23,6 @@
 
 @media screen and (max-width: 480px) {
   .card-inner {
-    width: 100%;
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     box-shadow: none;
@@ -45,7 +32,7 @@
 .card-thumbnail {
   display: block;
   width: 100%;
-  height: var(--card-thumbnail-height);
+  aspect-ratio: 4 / 3;
   overflow: hidden;
   background: var(--card-background-color);
 }

--- a/styles/util.css
+++ b/styles/util.css
@@ -122,8 +122,6 @@ figure,
 }
 
 .float-left,
-/* .card extends .float-left (see components/card.css) */
-.card,
 /* .color-bar > div extends .float-left (see components/header.css) */
 .color-bar > div,
 /* #social-nav a extends .float-left (see components/social-nav.css) */

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -25,7 +25,6 @@
 
   --card-width: 320px;
   --card-gutter-width: 40px;
-  --card-thumbnail-height: 240px;
   --card-background-color: var(--color-card-background);
   --width-of-three-columns: calc(var(--card-width) * 3 + var(--card-gutter-width) * 3);
   --width-of-two-columns: calc(var(--card-width) * 2 + var(--card-gutter-width) * 2);


### PR DESCRIPTION
This PR fixes homepage cards wrapping into a narrow column with empty space beside it. An auto-fit CSS grid fills the available width with one, two, or three columns, consistent 40px gutters, and proportional thumbnails.
